### PR TITLE
Add extern "C" to compile with C++ compiler.

### DIFF
--- a/src/cmaes_interface.h
+++ b/src/cmaes_interface.h
@@ -19,6 +19,10 @@
 /* ------------------ Interface ---------------------------- */
 /* --------------------------------------------------------- */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* --- initialization, constructors, destructors --- */
 double * cmaes_init(cmaes_t *, int dimension , double *xstart, 
 		double *stddev, long seed, int lambda, 
@@ -54,4 +58,7 @@ double *       cmaes_NewDouble(int n); /* user is responsible to free */
 void           cmaes_FATAL(char const *s1, char const *s2, char const *s3, 
 			   char const *s4);
 
+#ifdef __cplusplus
+} // end extern "C"
+#endif
 


### PR DESCRIPTION
At https://github.com/simbody/simbody, we are using this code with a C++ compiler. When building this code into our C++ library, I ran into linking issues. I'm not too experienced with working with C code, but from my googling, I found that I could add `extern "C"` around the declarations in `cmaes_interface.h`. This fixed the linker issues. 

I've made this change in our copy of the code. I'm submitting this PR in case you want this change in your repo.   Let me know if you think using extern "C" could lead to any issues.
