### PR TITLE
Ignore -Wunused-parameter in resume_distribution.

### DIFF
--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -403,8 +403,10 @@ cmaes_init(cmaes_t *t, /* "this" */
 /* --------------------------------------------------------- */
 /* --------------------------------------------------------- */
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
+#ifdef __GNUC__
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-result"
+#endif
 
 void 
 cmaes_resume_distribution(cmaes_t *t, char *filename)
@@ -525,7 +527,9 @@ cmaes_resume_distribution(cmaes_t *t, char *filename)
   cmaes_UpdateEigensystem(t, 1);
   
 } /* cmaes_resume_distribution() */
-#pragma GCC diagnostic pop
+#ifdef __GNUC__
+    #pragma GCC diagnostic pop
+#endif
 /* --------------------------------------------------------- */
 /* --------------------------------------------------------- */
 


### PR DESCRIPTION
GCC gives warnings about `cmaes_resume_distribution`. It seems that there may be good reasons to not use the return value of `fscanf` here, so maybe we can silence the warning?
