### PR TITLE
Close resume file at end of resume_distribution.

### DIFF
--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -479,6 +479,8 @@ cmaes_resume_distribution(cmaes_t *t, char *filename)
   t->flgresumedone = 1;
   cmaes_UpdateEigensystem(t, 1);
   
+  fclose(fp);
+  
 } /* cmaes_resume_distribution() */
 /* --------------------------------------------------------- */
 /* --------------------------------------------------------- */


### PR DESCRIPTION
On windows, I was trying to delete the resume file after I used it to resume an optimization. Windows wouldn't let me do it! I added a `fclose(fp)` at the end of `cmaes_resume_distribution` and this solved my problem.
