### PR TITLE
abs -> labs

### DIFF
--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -2340,7 +2340,7 @@ random_init( random_t *t, long unsigned inseed)
   if (inseed < 1) {
     while ((long) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications? */
-    inseed = (long unsigned)abs((long)(100*time(NULL)+clock()));
+    inseed = (long unsigned)labs((long)(100*time(NULL)+clock()));
   }
   return random_Start(t, inseed);
 }
@@ -2713,7 +2713,7 @@ readpara_SupplementDefaults(readpara_t *t)
   if (t->seed < 1) {
     while ((int) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications!? */
-    t->seed = (unsigned int)abs((long)(100*time(NULL)+clock()));
+    t->seed = (unsigned int)labs((long)(100*time(NULL)+clock()));
   }
 
   if (t->stStopFitness.flg == -1)


### PR DESCRIPTION
Fix clang warning `absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]`
