### PR TITLE
Fixed bounds warning (gcc 8.3.0)

### DIFF
--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -221,7 +221,6 @@ static double rgdouMax( const double *rgd, int len);
 static double rgdouMin( const double *rgd, int len);
 static double douMax( double d1, double d2);
 static double douMin( double d1, double d2);
-static int    intMin( int i, int j);
 static int    MaxIdx( const double *rgd, int len);
 static int    MinIdx( const double *rgd, int len);
 static double myhypot(double a, double b);
@@ -2481,9 +2480,20 @@ double cmaes_random_Uniform( cmaes_random_t *t)
   return (double)(t->aktrand)/(2.147483647e9);
 }
 
-static char *
-szCat(const char *sz1, const char*sz2, 
-      const char *sz3, const char *sz4);
+/* --------------------------------------------------------- */
+static void
+printErrorStrings(FILE *fd, char const *s1, char const *s2,
+                  char const *s3, char const *s4)
+{
+  if (s1 != NULL)
+    fprintf(fd, "%s", s1);
+  if (s2 != NULL)
+    fprintf(fd, " %s", s2);
+  if (s3 != NULL)
+    fprintf(fd, " %s", s3);
+  if (s4 != NULL)
+    fprintf(fd, " %s", s4);
+}
 
 /* --------------------------------------------------------- */
 /* -------------- Functions: cmaes_readpara_t -------------- */
@@ -2910,11 +2920,6 @@ douSquare(double d)
 {
   return d*d;
 }
-static int 
-intMin( int i, int j)
-{
-  return i < j ? i : j;
-}
 static double
 douMax( double i, double j)
 {
@@ -3072,8 +3077,9 @@ cmaes_FATAL(char const *s1, char const *s2, char const *s3,
   time_t t = time(NULL);
   ERRORMESSAGE( s1, s2, s3, s4);
   ERRORMESSAGE("*** Exiting cmaes_t ***",0,0,0);
-  printf("\n -- %s %s\n", asctime(localtime(&t)), 
-           s2 ? szCat(s1, s2, s3, s4) : s1);
+  printf("\n -- %s ", asctime(localtime(&t)));
+  printErrorStrings(stdout, s1, s2, s3, s4);
+  printf("\n");
   printf(" *** CMA-ES ABORTED, see errcmaes.err *** \n");
   fflush(stdout);
   exit(1);
@@ -3095,43 +3101,21 @@ static void ERRORMESSAGE( char const *s1, char const *s2,
   /*  static char szBuf[700];  desirable but needs additional input argument 
       sprintf(szBuf, "%f:%f", gen, gen*lambda);
   */
-  time_t t = time(NULL);
   FILE *fp = fopen( "errcmaes.err", "a");
-  if (!fp)
-    {
-      printf("\nFATAL ERROR: %s\n", s2 ? szCat(s1, s2, s3, s4) : s1);
-      printf("cmaes_t could not open file 'errcmaes.err'.");
-      printf("\n *** CMA-ES ABORTED *** ");
-      fflush(stdout);
-      exit(1);
-    }
-  fprintf( fp, "\n -- %s %s\n", asctime(localtime(&t)), 
-           s2 ? szCat(s1, s2, s3, s4) : s1);
-  fclose (fp);
+  if (fp == NULL) {
+    printf("\nFATAL ERROR: ");
+    printErrorStrings(stdout, s1, s2, s3, s4);
+    printf("\n");
+    printf("cmaes_t could not open file 'errcmaes.err'.");
+    printf("\n *** CMA-ES ABORTED *** ");
+    fflush(stdout);
+    exit(1);
+  } else {
+    time_t t = time(NULL);
+    fprintf(fp, "\n -- %s ", asctime(localtime(&t)));
+    printErrorStrings(fp, s1, s2, s3, s4);
+    fprintf(fp, "\n");
+    fclose (fp);
+  }
 #endif
 }
-
-/* ========================================================= */
-static char *szCat(const char *sz1, const char*sz2, 
-                   const char *sz3, const char *sz4)
-{
-  static char szBuf[700];
-
-  if (!sz1)
-    FATAL("szCat() : Invalid Arguments",0,0,0);
-
-  strncpy ((char *)szBuf, sz1, (unsigned)intMin( (int)strlen(sz1), 698));
-  szBuf[intMin( (int)strlen(sz1), 698)] = '\0';
-  if (sz2)
-    strncat ((char *)szBuf, sz2, 
-             (unsigned)intMin((int)strlen(sz2)+1, 698 - (int)strlen((char const *)szBuf)));
-  if (sz3)
-    strncat((char *)szBuf, sz3, 
-            (unsigned)intMin((int)strlen(sz3)+1, 698 - (int)strlen((char const *)szBuf)));
-  if (sz4)
-    strncat((char *)szBuf, sz4, 
-            (unsigned)intMin((int)strlen(sz4)+1, 698 - (int)strlen((char const *)szBuf)));
-  return (char *) szBuf;
-}
-
-


### PR DESCRIPTION
Hi, I'm compiling [OpenSim](https://github.com/opensim-org/opensim-core) and [SimBody](https://github.com/simbody/simbody), which depend on this code. When compiling under gcc 8.3.0, I get the following warning:

```text
c-cmaes/src/cmaes.c: In function ‘szCat’:
c-cmaes/src/cmaes.c:3118:3: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
   strncpy ((char *)szBuf, sz1, (unsigned)intMin( (int)strlen(sz1), 698));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

# multiple times
```

The code is logically correct, but I think gcc is confused by the usage of `intMin`? Either way, I looked into the source and initially tried to fix `szCat`, but it seems to be doing a fair amount of buffer juggling just to concatenate some strings into a static buffer. This proposed change removes `szCat`, replacing it with a print helper function that should, I hope, have the same side-effects as the original implementation but with slightly simpler code.

I would be very grateful to get this fix--or, at least, some other fix that removes the gcc warning--pulled into this repo, so that those downstream projects (OpenSim/SimBody) can pull the latest `c-cmaes`, rather than us having to disable warnings, or customize the code.

I can change/modify this PR if you do not like the style or implementation approach, just shoot off a reply and I'll get on it.
