### PR TITLE
Removed merge conflict form source header

### DIFF
--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -99,6 +99,7 @@
   14/10/18: splitted cmaes_init() into cmaes_init_para() and cmaes_init_final(),
             such that parameters can be set also comparatively safely within the
             code, namely after calling cmaes_init_para(). The order of parameters
+            of readpara_init() has changed to be the same as for cmaes_init().
   14/11/25:  fix warnings from Microsoft C compiler (sherm)
   14/11/26: renamed exported symbols so they begin with a cmaes_prefix.
   

--- a/src/cmaes.c
+++ b/src/cmaes.c
@@ -99,13 +99,8 @@
   14/10/18: splitted cmaes_init() into cmaes_init_para() and cmaes_init_final(),
             such that parameters can be set also comparatively safely within the
             code, namely after calling cmaes_init_para(). The order of parameters
-<<<<<<< HEAD
-            of readpara_init() has changed to be the same as for cmaes_init().
-  14/11/25  fix warnings from Microsoft C compiler (sherm)
-=======
-            of readpara_init() has changed to be the same as for cmaes_init(). 
+  14/11/25:  fix warnings from Microsoft C compiler (sherm)
   14/11/26: renamed exported symbols so they begin with a cmaes_prefix.
->>>>>>> bd5aeb2a21fbc437f1b322610022f7cb1ba6a9db
   
   Wish List
     o make signals_filename part of cmaes_t using assign_string()


### PR DESCRIPTION
Hi,

This PR removes a merge conflict that was committed into `master` at some point. It wasn't caught by the compiler because it is in `cmaes.c`'s file header. It was spotted while merging the latest `master` into simbody here:

https://github.com/simbody/simbody/pull/690

This is just a cosmetic, rather than functional, change.

